### PR TITLE
update `ScopeTemplate` and `ScopeInstance` controllers to use server-side apply for updating RBAC

### DIFF
--- a/controllers/scopeinstance_controller.go
+++ b/controllers/scopeinstance_controller.go
@@ -59,8 +59,7 @@ const (
 
 	// generateNames are used to track each binding we create for a single scopeTemplate
 	clusterRoleBindingGenerateKey = "operators.coreos.io/generateName"
-
-	scopeInstanceControllerFieldOwner = "scopeinstance-controller"
+	siCtrlFieldOwner              = "scopeinstance-controller"
 )
 
 //+kubebuilder:rbac:groups=operators.io.operator-framework,resources=scopeinstances,verbs=get;list;watch;create;update;patch;delete
@@ -219,7 +218,11 @@ func (r *ScopeInstanceReconciler) ensureBindings(ctx context.Context, in *operat
 
 			// server-side apply patch
 			existingCRB.ManagedFields = nil
-			if err := r.Client.Patch(ctx, existingCRB, client.Apply, client.FieldOwner(scopeInstanceControllerFieldOwner), client.ForceOwnership); err != nil {
+			if err := r.Client.Patch(ctx,
+				existingCRB,
+				client.Apply,
+				client.FieldOwner(siCtrlFieldOwner),
+				client.ForceOwnership); err != nil {
 				return err
 			}
 
@@ -293,7 +296,11 @@ func (r *ScopeInstanceReconciler) ensureBindings(ctx context.Context, in *operat
 
 				// server-side apply patch
 				existingRB.ManagedFields = nil
-				if err := r.Client.Patch(ctx, existingRB, client.Apply, client.FieldOwner(scopeInstanceControllerFieldOwner), client.ForceOwnership); err != nil {
+				if err := r.Client.Patch(ctx,
+					existingRB,
+					client.Apply,
+					client.FieldOwner(siCtrlFieldOwner),
+					client.ForceOwnership); err != nil {
 					return err
 				}
 			}

--- a/controllers/scopeinstance_controller.go
+++ b/controllers/scopeinstance_controller.go
@@ -59,6 +59,8 @@ const (
 
 	// generateNames are used to track each binding we create for a single scopeTemplate
 	clusterRoleBindingGenerateKey = "operators.coreos.io/generateName"
+
+	scopeInstanceControllerFieldOwner = "scopeinstance-controller"
 )
 
 //+kubebuilder:rbac:groups=operators.io.operator-framework,resources=scopeinstances,verbs=get;list;watch;create;update;patch;delete
@@ -215,7 +217,9 @@ func (r *ScopeInstanceReconciler) ensureBindings(ctx context.Context, in *operat
 			existingCRB.OwnerReferences = crb.OwnerReferences
 			existingCRB.Subjects = crb.Subjects
 
-			if err := r.Client.Update(ctx, existingCRB); err != nil {
+			// server-side apply patch
+			existingCRB.ManagedFields = nil
+			if err := r.Client.Patch(ctx, existingCRB, client.Apply, client.FieldOwner(scopeInstanceControllerFieldOwner), client.ForceOwnership); err != nil {
 				return err
 			}
 
@@ -287,7 +291,9 @@ func (r *ScopeInstanceReconciler) ensureBindings(ctx context.Context, in *operat
 				existingRB.OwnerReferences = rb.OwnerReferences
 				existingRB.Subjects = rb.Subjects
 
-				if err := r.Client.Update(ctx, existingRB); err != nil {
+				// server-side apply patch
+				existingRB.ManagedFields = nil
+				if err := r.Client.Patch(ctx, existingRB, client.Apply, client.FieldOwner(scopeInstanceControllerFieldOwner), client.ForceOwnership); err != nil {
 					return err
 				}
 			}

--- a/controllers/scopetemplate_controller.go
+++ b/controllers/scopetemplate_controller.go
@@ -50,8 +50,8 @@ type ScopeTemplateReconciler struct {
 
 const (
 	// generateNames are used to track each binding we create for a single scopeTemplate
-	clusterRoleGenerateKey            = "operators.coreos.io/generateName"
-	scopeTemplateControllerFieldOwner = "scopetemplate-controller"
+	clusterRoleGenerateKey = "operators.coreos.io/generateName"
+	stCtrlFieldOwner       = "scopetemplate-controller"
 )
 
 //+kubebuilder:rbac:groups=operators.io.operator-framework,resources=scopetemplates,verbs=get;list;watch;create;update;patch;delete
@@ -211,7 +211,11 @@ func (r *ScopeTemplateReconciler) ensureClusterRoles(ctx context.Context, st *op
 
 		// server-side apply patch
 		existingCRB.ManagedFields = nil
-		if err := r.Client.Patch(ctx, existingCRB, client.Apply, client.FieldOwner(scopeTemplateControllerFieldOwner), client.ForceOwnership); err != nil {
+		if err := r.Client.Patch(ctx,
+			existingCRB,
+			client.Apply,
+			client.FieldOwner(stCtrlFieldOwner),
+			client.ForceOwnership); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description of the Change
- Convert `r.Client.Update()` calls in `ScopeTemplate` controller to `r.Client.Patch()` that uses the `client.Apply` patch type
    - Create a constant used for setting the field owner to the `ScopeTemplate` controller when applying patches
- Convert `r.Client.Update()` calls in `ScopeInstance` controller to `r.Client.Patch()` that uses the `client.Apply` patch type
    - Create a constant used for setting the field owner to the `ScopeInstance` controller when applying patches

## Motivation for the Change
- Fixes #7 