### PR TITLE
update util/util_test.go to use the v1alpha1 package instead of v1

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -7,7 +7,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorsv1 "awgreene/scope-operator/api/v1"
+	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
 )
 
 var _ = Describe("Util", func() {
@@ -220,7 +220,7 @@ var _ = Describe("Util", func() {
 			}
 
 			hash := HashObject(si.Spec)
-			Expect(hash).Should(Equal("5b568d69c6"))
+			Expect(hash).Should(Equal("577777495c"))
 		})
 		It("should return a hash for an empty string", func() {
 			hash := HashObject("")


### PR DESCRIPTION
## Description of the change
Make necessary updates in `util/util_test.go` to properly use the `v1alpha1` package instead of the `v1` package. 

## Motivation for the change
I missed updating this in #22 before merging it. My bad :grimacing: 