### PR TITLE
set watches on owned resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-
+# Version of the image to use when building/pushing image targets
+VERSION ?= 0.0.1
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/agreene/oria-operator:latest
+IMG ?= quay.io/operator-framework/oria-operator:v$(VERSION)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: quay.io/operator-framework/oria-operator
+  newTag: v0.0.1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -75,6 +75,7 @@ rules:
   resources:
   - clusterroles
   verbs:
+  - bind
   - create
   - delete
   - escalate

--- a/controllers/scopeinstance_controller.go
+++ b/controllers/scopeinstance_controller.go
@@ -349,6 +349,8 @@ func (r *ScopeInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorsv1.ScopeInstance{}).
 		Watches(&source.Kind{Type: &operatorsv1.ScopeTemplate{}}, handler.EnqueueRequestsFromMapFunc(r.mapToScopeInstance)).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }
 

--- a/controllers/scopetemplate_controller.go
+++ b/controllers/scopetemplate_controller.go
@@ -63,7 +63,7 @@ const (
 //+kubebuilder:rbac:groups=operators.io.operator-framework,resources=scopetemplates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operators.io.operator-framework,resources=scopetemplates/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=operators.io.operator-framework,resources=scopetemplates/finalizers,verbs=update
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;escalate
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;escalate;bind
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -155,6 +155,7 @@ func (r *ScopeTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&operatorsv1.ScopeTemplate{}).
 		// Set up a watch for ScopeInstance to handle requeuing of requests for ScopeTemplate
 		Watches(&source.Kind{Type: &operatorsv1.ScopeInstance{}}, handler.EnqueueRequestsFromMapFunc(r.mapToScopeTemplate)).
+		Owns(&rbacv1.ClusterRole{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
**Description of changes:**
- Updated `controllers/scopeinstance_controller.go` to setup watches for `(Cluster)RoleBinding` resources by utilizing the `Owns()` function as part of setting up the manager.
- Updated `controllers/scopetemplate_controller.go` to setup watches for `ClusterRole` resources by utilizing the `Owns()` function as part of setting up the manager.
- Some additional minor updates to (I felt they were to small to warrant a separate PR):
    - Update the permissions for `ClusterRole` resources to include the `bind` verb. This allows us to create bindings for `ClusterRole`s even if the `ServiceAccount` itself doesn't have the permissions.
    - Update the Makefile to include a version that we can update when building our images so that we don't always use `latest`
    - Update the Makefile `IMG` env var to default to `quay.io/operator-framework/oria-operator:v$(VERSION)` instead of `quay.io/agreene/oria-operator:latest` or `controller:latest`

**Motivation for the change:**
- fixes #6 