### PR TITLE
(actions): Add GH Action to release oria-operator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore build and test binaries.
-bin/
-testbin/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,67 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ~1.18
+    
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        install-only: true
+
+    - name: Docker Login
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Set the release related variables
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          # Release tags.
+          echo IMAGE_TAG="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo GORELEASER_ARGS="--rm-dist" >> $GITHUB_ENV
+          echo DISABLE_RELEASE_PIPELINE=false >> $GITHUB_ENV
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          # Branch build.
+          echo IMAGE_TAG="$(echo "${GITHUB_REF#refs/heads/}" | sed -r 's|/+|-|g')" >> $GITHUB_ENV
+          echo GORELEASER_ARGS="--rm-dist --skip-validate" >> $GITHUB_ENV
+        elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          # PR build.
+          echo IMAGE_TAG="pr-$(echo "${GITHUB_REF}" | sed -E 's|refs/pull/([^/]+)/?.*|\1|')" >> $GITHUB_ENV
+        else
+          echo IMAGE_TAG="$(git describe --tags --always)" >> $GITHUB_ENV
+        fi
+
+    - name: Generate oria-operator release manifests
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: make release-manifests
+
+    - name: Run goreleaser
+      run: make release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 # vendor/
 **/bin/
 .vscode/*
+
+# release files
+.goreleaser.yml
+oria-operator.yaml
+oria-operator

--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -1,0 +1,75 @@
+env:
+- GOPROXY=https://proxy.golang.org|direct
+- GO111MODULE=on
+- CGO_ENABLED=0
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+builds:
+  - id: oria-operator
+    main: main.go
+    binary: oria-operator
+    goos: 
+    - linux
+    goarch:
+    - amd64
+    - arm64
+    - ppc64le
+    - s390x
+dockers:
+- image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+  dockerfile: Dockerfile
+  use: buildx
+  goos: linux
+  goarch: amd64
+  build_flag_templates:
+  - --platform=linux/amd64
+- image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+  dockerfile: Dockerfile
+  use: buildx
+  goos: linux
+  goarch: arm64
+  build_flag_templates:
+  - --platform=linux/arm64
+- image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+  dockerfile: Dockerfile
+  use: buildx
+  goos: linux
+  goarch: ppc64le
+  build_flag_templates:
+  - --platform=linux/ppc64le
+- image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+  dockerfile: Dockerfile
+  use: buildx
+  goos: linux
+  goarch: s390x
+  build_flag_templates:
+  - --platform=linux/s390x
+docker_manifests:
+- name_template: "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
+  image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  use: github-native
+  skip: $DISABLE_RELEASE_PIPELINE
+release:
+  disable: $DISABLE_RELEASE_PIPELINE
+  extra_files:
+  - glob: 'oria-operator.yaml'
+  header: |
+    ## Installation
+    ```bash
+    kubectl apply -f https://github.com/operator-framework/oria-operator/releases/download/{{ .Tag }}/oria-operator.yaml
+    ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,5 @@
-# Build the manager binary
-FROM golang:1.18 as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-COPY util/ util/
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
-
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base:debug-nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
+COPY oria-operator oria-operator
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT [ "/oria-operator" ]

--- a/Dockerfile.plainbundle
+++ b/Dockerfile.plainbundle
@@ -1,0 +1,2 @@
+FROM scratch
+COPY ./manifests /manifests

--- a/Makefile
+++ b/Makefile
@@ -82,19 +82,25 @@ lint: golangci-lint ## Run golangci-lint linter
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -o oria-operator main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: test build ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+.PHONY: bundle
+bundle: kustomize
+	mkdir -p manifests
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > manifests/manifests.yaml
 
 ##@ Deployment
 
@@ -157,3 +163,21 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 
+##@ Release
+export DISABLE_RELEASE_PIPELINE ?= true
+export IMAGE_REPO ?= quay.io/rh_ee_bpalmer/oria-operator
+export IMAGE_TAG ?= latest
+.PHONY: release
+release: GORELEASER ?= goreleaser
+release: GORELEASER_ARGS ?= --snapshot --rm-dist
+release: substitute
+	$(GORELEASER) $(GORELEASER_ARGS)
+
+.PHONY: substitute
+substitute:
+	envsubst < .goreleaser.template.yml > .goreleaser.yml
+
+.PHONY: release-manifests
+release-manifests: RELEASE_VERSION ?= $(shell git describe --abbrev=0 --tags)
+release-manifests: bundle
+	cat manifests/manifests.yaml | sed "s/:v$(VERSION)/:$(RELEASE_VERSION)/g" > oria-operator.yaml

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 
 ##@ Release
 export DISABLE_RELEASE_PIPELINE ?= true
-export IMAGE_REPO ?= quay.io/rh_ee_bpalmer/oria-operator
+export IMAGE_REPO ?= quay.io/operator-framework/oria-operator
 export IMAGE_TAG ?= latest
 .PHONY: release
 release: GORELEASER ?= goreleaser

--- a/README.md
+++ b/README.md
@@ -227,4 +227,3 @@ Oria Operator is under Apache 2.0 license. See the [LICENSE][license_file] file 
 [operator-framework-communication]: https://github.com/operator-framework/community#get-involved
 [operator-framework-meetings]: https://github.com/operator-framework/community#meetings
 [contribution-docs]: https://sdk.operatorframework.io/docs/contribution-guidelines/
-

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         #   type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - /oria-operator
         args:
         - --leader-elect
         image: controller:latest

--- a/manifests/manifests.yaml
+++ b/manifests/manifests.yaml
@@ -1,0 +1,486 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: scope-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: scopeinstances.operators.io.operator-framework
+spec:
+  group: operators.io.operator-framework
+  names:
+    kind: ScopeInstance
+    listKind: ScopeInstanceList
+    plural: scopeinstances
+    singular: scopeinstance
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScopeInstance is the Schema for the scopeinstances API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScopeInstanceSpec defines the desired state of ScopeInstance
+            properties:
+              namespaces:
+                items:
+                  type: string
+                type: array
+              scopeTemplateName:
+                description: Foo is an example field of ScopeInstance. Edit scopeinstance_types.go to remove/update
+                type: string
+            type: object
+          status:
+            description: ScopeInstanceStatus defines the observed state of ScopeInstance
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: scopetemplates.operators.io.operator-framework
+spec:
+  group: operators.io.operator-framework
+  names:
+    kind: ScopeTemplate
+    listKind: ScopeTemplateList
+    plural: scopetemplates
+    singular: scopetemplate
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScopeTemplate is the Schema for the scopetemplates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScopeTemplateSpec defines the desired state of ScopeTemplate
+            properties:
+              clusterRoles:
+                description: Foo is an example field of ScopeTemplate. Edit scopetemplate_types.go to remove/update
+                items:
+                  properties:
+                    generateName:
+                      type: string
+                    rules:
+                      items:
+                        description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                        properties:
+                          apiGroups:
+                            description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                            items:
+                              type: string
+                            type: array
+                          nonResourceURLs:
+                            description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                            items:
+                              type: string
+                            type: array
+                          resourceNames:
+                            description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                            items:
+                              type: string
+                            type: array
+                          resources:
+                            description: Resources is a list of resources this rule applies to. '*' represents all resources.
+                            items:
+                              type: string
+                            type: array
+                          verbs:
+                            description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - verbs
+                        type: object
+                      type: array
+                    subjects:
+                      items:
+                        description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                        properties:
+                          apiGroup:
+                            description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                            type: string
+                          kind:
+                            description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                            type: string
+                          name:
+                            description: Name of the object being referenced.
+                            type: string
+                          namespace:
+                            description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - generateName
+                  - rules
+                  - subjects
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ScopeTemplateStatus defines the observed state of ScopeTemplate
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scope-operator-controller-manager
+  namespace: scope-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scope-operator-leader-election-role
+  namespace: scope-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: scope-operator-manager-role
+rules:
+- apiGroups:
+  - operators.io.operator-framework
+  resources:
+  - scopeinstances
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.io.operator-framework
+  resources:
+  - scopeinstances/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operators.io.operator-framework
+  resources:
+  - scopeinstances/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - operators.io.operator-framework
+  resources:
+  - scopetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.io.operator-framework
+  resources:
+  - scopetemplates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operators.io.operator-framework
+  resources:
+  - scopetemplates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scope-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scope-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scope-operator-leader-election-rolebinding
+  namespace: scope-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scope-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: scope-operator-controller-manager
+  namespace: scope-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scope-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scope-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: scope-operator-controller-manager
+  namespace: scope-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scope-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scope-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: scope-operator-controller-manager
+  namespace: scope-operator-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 17ccecbb.io.operator-framework
+    # leaderElectionReleaseOnCancel defines if the leader should step down volume
+    # when the Manager ends. This requires the binary to immediately end when the
+    # Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+    # speeds up voluntary leader transitions as the new leader don't have to wait
+    # LeaseDuration time first.
+    # In the default scaffold provided, the program ends immediately after
+    # the manager stops, so would be fine to enable this option. However,
+    # if you are doing or is intended to do any operation such as perform cleanups
+    # after the manager stops then its usage might be unsafe.
+    # leaderElectionReleaseOnCancel: true
+kind: ConfigMap
+metadata:
+  name: scope-operator-manager-config
+  namespace: scope-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: scope-operator-controller-manager-metrics-service
+  namespace: scope-operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: scope-operator-controller-manager
+  namespace: scope-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /oria-operator
+        image: quay.io/operator-framework/oria-operator:v0.0.1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: scope-operator-controller-manager
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
**Description**
- Add a GH Action to use goreleaser to release oria-operator
- Update Makefile to add/update targets to work with the release 
- Update Dockerfile to work with the release process
- Add a `Dockerfile.plainbundle` file that we can use in the future to release a RukPak plain+v0 bundle image
- Update `config/manager/manager.yaml` to use `/oria-operator` as the command instead of `/manager`

**Motivation**
- fixes #45

**Additional Information**
I noticed when testing this GH Action that goreleaser will fail to properly generate the release notes if there was not a previous tag. For our alpha release we could manually create the release and in the future the action will take care of it OR we can tag the first ever commit with a tag and then when we tag for the release the action will handle it all.

With this action to create a release is as simple as `git tag -a vX.X.X` and `git push origin vX.X.X`

We will also need to add some secrets to this repo for logging in and pushing images to `quay.io/operator-framework/oria-operator`. The secret names will need to be `QUAY_USERNAME` and `QUAY_PASSWORD`