### PR TITLE
update awgreene/scope-operator references to operator-framework/oria-operator

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: io.operator-framework
 layout:
 - go.kubebuilder.io/v3
 projectName: oria-operator
-repo: awgreene/oria-operator
+repo: operator-framework/oria-operator
 resources:
 - api:
     crdVersion: v1alpha1
@@ -11,7 +11,7 @@ resources:
   domain: io.operator-framework
   group: operators
   kind: ScopeInstance
-  path: awgreene/oria-operator/api/v1alpha1
+  path: operator-framework/oria-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1alpha1
@@ -20,6 +20,6 @@ resources:
   domain: io.operator-framework
   group: operators
   kind: ScopeTemplate
-  path: awgreene/oria-operator/api/v1alpha1
+  path: operator-framework/oria-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/PROJECT
+++ b/PROJECT
@@ -1,8 +1,8 @@
 domain: io.operator-framework
 layout:
 - go.kubebuilder.io/v3
-projectName: scope-operator
-repo: awgreene/scope-operator
+projectName: oria-operator
+repo: awgreene/oria-operator
 resources:
 - api:
     crdVersion: v1alpha1
@@ -11,7 +11,7 @@ resources:
   domain: io.operator-framework
   group: operators
   kind: ScopeInstance
-  path: awgreene/scope-operator/api/v1alpha1
+  path: awgreene/oria-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1alpha1
@@ -20,6 +20,6 @@ resources:
   domain: io.operator-framework
   group: operators
   kind: ScopeTemplate
-  path: awgreene/scope-operator/api/v1alpha1
+  path: awgreene/oria-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: scope-operator-system
+namespace: oria-operator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: scope-operator-
+namePrefix: oria-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/controllers/scopeinstance_controller.go
+++ b/controllers/scopeinstance_controller.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
-	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
-	"awgreene/scope-operator/util"
+	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
+	"awgreene/oria-operator/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/controllers/scopeinstance_controller.go
+++ b/controllers/scopeinstance_controller.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
-	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
-	"awgreene/oria-operator/util"
+	operatorsv1 "operator-framework/oria-operator/api/v1alpha1"
+	"operator-framework/oria-operator/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/controllers/scopetemplate_controller.go
+++ b/controllers/scopetemplate_controller.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
-	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
-	"awgreene/scope-operator/util"
+	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
+	"awgreene/oria-operator/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/controllers/scopetemplate_controller.go
+++ b/controllers/scopetemplate_controller.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
-	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
-	"awgreene/oria-operator/util"
+	operatorsv1 "operator-framework/oria-operator/api/v1alpha1"
+	"operator-framework/oria-operator/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/controllers/scopetemplate_controller_test.go
+++ b/controllers/scopetemplate_controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
+	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
 )
 
 const (

--- a/controllers/scopetemplate_controller_test.go
+++ b/controllers/scopetemplate_controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
+	operatorsv1 "operator-framework/oria-operator/api/v1alpha1"
 )
 
 const (

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,7 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
+	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,7 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
+	operatorsv1 "operator-framework/oria-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module awgreene/scope-operator
+module awgreene/oria-operator
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module awgreene/oria-operator
+module operator-framework/oria-operator
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
-	"awgreene/scope-operator/controllers"
+	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
+	"awgreene/oria-operator/controllers"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
-	"awgreene/oria-operator/controllers"
+	operatorsv1 "operator-framework/oria-operator/api/v1alpha1"
+	"operator-framework/oria-operator/controllers"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/manifests/manifests.yaml
+++ b/manifests/manifests.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: scope-operator-system
+  name: oria-operator-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -165,14 +165,14 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: scope-operator-controller-manager
-  namespace: scope-operator-system
+  name: oria-operator-controller-manager
+  namespace: oria-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: scope-operator-leader-election-role
-  namespace: scope-operator-system
+  name: oria-operator-leader-election-role
+  namespace: oria-operator-system
 rules:
 - apiGroups:
   - ""
@@ -210,7 +210,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: scope-operator-manager-role
+  name: oria-operator-manager-role
 rules:
 - apiGroups:
   - operators.io.operator-framework
@@ -295,7 +295,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: scope-operator-metrics-reader
+  name: oria-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -305,7 +305,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: scope-operator-proxy-role
+  name: oria-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -323,42 +323,42 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: scope-operator-leader-election-rolebinding
-  namespace: scope-operator-system
+  name: oria-operator-leader-election-rolebinding
+  namespace: oria-operator-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: scope-operator-leader-election-role
+  name: oria-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: scope-operator-controller-manager
-  namespace: scope-operator-system
+  name: oria-operator-controller-manager
+  namespace: oria-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: scope-operator-manager-rolebinding
+  name: oria-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: scope-operator-manager-role
+  name: oria-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: scope-operator-controller-manager
-  namespace: scope-operator-system
+  name: oria-operator-controller-manager
+  namespace: oria-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: scope-operator-proxy-rolebinding
+  name: oria-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: scope-operator-proxy-role
+  name: oria-operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: scope-operator-controller-manager
-  namespace: scope-operator-system
+  name: oria-operator-controller-manager
+  namespace: oria-operator-system
 ---
 apiVersion: v1
 data:
@@ -386,16 +386,16 @@ data:
     # leaderElectionReleaseOnCancel: true
 kind: ConfigMap
 metadata:
-  name: scope-operator-manager-config
-  namespace: scope-operator-system
+  name: oria-operator-manager-config
+  namespace: oria-operator-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: scope-operator-controller-manager-metrics-service
-  namespace: scope-operator-system
+  name: oria-operator-controller-manager-metrics-service
+  namespace: oria-operator-system
 spec:
   ports:
   - name: https
@@ -410,8 +410,8 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-  name: scope-operator-controller-manager
-  namespace: scope-operator-system
+  name: oria-operator-controller-manager
+  namespace: oria-operator-system
 spec:
   replicas: 1
   selector:
@@ -482,5 +482,5 @@ spec:
             - ALL
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: scope-operator-controller-manager
+      serviceAccountName: oria-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -7,7 +7,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
+	operatorsv1 "operator-framework/oria-operator/api/v1alpha1"
 )
 
 var _ = Describe("Util", func() {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -7,7 +7,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorsv1 "awgreene/scope-operator/api/v1alpha1"
+	operatorsv1 "awgreene/oria-operator/api/v1alpha1"
 )
 
 var _ = Describe("Util", func() {


### PR DESCRIPTION
**Description of the change**:
- update all references of `scope-operator` to now be `oria-operator`

This was done with the command: 
```
ag -l scope-operator | xargs -n 1 sed -i 's/scope-operator/oria-operator/g'
```

- update all references of `awgreene` to now be `operator-framework`

This was done with the command:
```
ag -l awgreene | xargs -n 1 sed -i 's/awgreene/operator-framework/g' 
```